### PR TITLE
PHP-CS-Fixer bridge for StyleCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,21 @@
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
+$header = <<<EOF
+This file is part of the FOSMessage library.
+
+(c) Titouan Galopin <galopintitouan@gmail.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+HeaderCommentFixer::setHeader($header);
+
+return ConfigBridge::create()
+    ->setUsingCache(true)
+;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.9",
-        "doctrine/orm": "^2.5.1"
+        "doctrine/orm": "^2.5.1",
+        "sllh/php-cs-fixer-styleci-bridge": "~1.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I propose you to integrate this bridge that will permit to contributors to fix CS with `php-cs-fixer fix` command easily with `.styleci.yml` configuration interpretation.

The command to run the fixer is still the same:

``` bash
php-cs-fixer fix -v
```

The difference is StyleCI configuration is synced with PHP-CS-Fixer to avoid mistakes.
