### PR TITLE
Reorganize event dispatching and add some events

### DIFF
--- a/src/EventDispatcher/EventDispatcherInterface.php
+++ b/src/EventDispatcher/EventDispatcherInterface.php
@@ -22,10 +22,14 @@ use FOS\Message\Event\MessageEvent;
 interface EventDispatcherInterface
 {
     /**
-     * Event name for dispatchers needing an event name.
-     * The native dispatcher does not need one so it simply does not use this constant.
+     * PRE_PERSIST is dispatched right before entities are persisted and flushed.
      */
-    const EVENT_NAME = 'fos_message';
+    const PRE_PERSIST = 'fos_message.pre_persist';
+
+    /**
+     * POST_PERSIST is dispatched right after entities are persisted and flushed.
+     */
+    const POST_PERSIST = 'fos_message.post_persist';
 
     /**
      * Dispatch an event and return the result.
@@ -33,9 +37,13 @@ interface EventDispatcherInterface
      * A ConversationEvent is dispatched when a conversation is started.
      * A MessageEvent is dispatched when a message is sent in a conversation.
      *
+     * See the FOSMessageEvents class for the exhaustive list of the events
+     * dispatched by FOSMessage.
+     *
+     * @param string                         $eventName
      * @param MessageEvent|ConversationEvent $event
      *
      * @return MessageEvent
      */
-    public function dispatch(MessageEvent $event);
+    public function dispatch($eventName, MessageEvent $event);
 }

--- a/src/EventDispatcher/NativeEventDispatcher.php
+++ b/src/EventDispatcher/NativeEventDispatcher.php
@@ -25,11 +25,17 @@ use Webmozart\Assert\Assert;
  * ``` php
  * $dispatcher = new NativeEventDispatcher();
  *
- * $dispatcher->addListener(function(MessageEvent $event) {
+ * $dispatcher->addListener(function($eventName, MessageEvent $event) {
  *      if ($event instanceof ConversationEvent) {
  *          // Event is a new conversation
  *      } else {
  *          // Event is an answer to a conversation
+ *      }
+ *
+ *      if ($eventName === FOSMessageEvents::PRE_PERSIST) {
+ *          // Before persist
+ *      } elseif ($eventName === FOSMessageEvents::POST_PERSIST) {
+ *          // After persist
  *      }
  * });
  *
@@ -80,10 +86,10 @@ class NativeEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch(MessageEvent $event)
+    public function dispatch($eventName, MessageEvent $event)
     {
         foreach ($this->listeners as $listener) {
-            $event = call_user_func_array($listener, [$event]);
+            $event = call_user_func_array($listener, [$eventName, $event]);
         }
 
         return $event;

--- a/src/EventDispatcher/SymfonyBridgeEventDispatcher.php
+++ b/src/EventDispatcher/SymfonyBridgeEventDispatcher.php
@@ -18,10 +18,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDi
 /**
  * Event dispatcher to send events to the Symfony event dispatcher.
  *
- * Simply provides the Symfony dispatcher and this bridge will dispatch
- * into it the event with name the value of EventDispatcherInterface::EVENT_NAME.
- *
- * You can use the bundle (FOSMessageBundle) if you want to integrate the library in Symfony.
+ * Simply provides the Symfony dispatcher and this bridge will forward
+ * the library event to the Symfony event dispatcher.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
@@ -45,8 +43,8 @@ class SymfonyBridgeEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch(MessageEvent $event)
+    public function dispatch($eventName, MessageEvent $event)
     {
-        return $this->symfonyDispatcher->dispatch(EventDispatcherInterface::EVENT_NAME, new SymfonyEvent($event));
+        return $this->symfonyDispatcher->dispatch($eventName, new SymfonyEvent($event));
     }
 }

--- a/tests/SenderTest.php
+++ b/tests/SenderTest.php
@@ -150,6 +150,12 @@ class SenderTest extends PHPUnit_Framework_TestCase
             ->with($secondMessageModel)
             ->andReturn(true);
 
+        // Dispatcher
+        $this->dispatcher->shouldReceive('dispatch')
+            ->with(EventDispatcherInterface::PRE_PERSIST, Mockery::type('FOS\Message\Event\ConversationEvent'))
+            ->once()
+            ->andReturn(true);
+
         // Final flush
         $this->driver->shouldReceive('flush')
             ->once()
@@ -158,7 +164,7 @@ class SenderTest extends PHPUnit_Framework_TestCase
 
         // Dispatcher
         $this->dispatcher->shouldReceive('dispatch')
-            ->with(Mockery::type('FOS\Message\Event\ConversationEvent'))
+            ->with(EventDispatcherInterface::POST_PERSIST, Mockery::type('FOS\Message\Event\ConversationEvent'))
             ->once()
             ->andReturn(true);
 
@@ -248,6 +254,12 @@ class SenderTest extends PHPUnit_Framework_TestCase
             ->with($secondMessageModel)
             ->andReturn(true);
 
+        // Dispatcher
+        $this->dispatcher->shouldReceive('dispatch')
+            ->with(EventDispatcherInterface::PRE_PERSIST, Mockery::type('FOS\Message\Event\MessageEvent'))
+            ->once()
+            ->andReturn(true);
+
         // Final flush
         $this->driver->shouldReceive('flush')
             ->once()
@@ -256,7 +268,7 @@ class SenderTest extends PHPUnit_Framework_TestCase
 
         // Dispatcher
         $this->dispatcher->shouldReceive('dispatch')
-            ->with(Mockery::type('FOS\Message\Event\MessageEvent'))
+            ->with(EventDispatcherInterface::POST_PERSIST, Mockery::type('FOS\Message\Event\MessageEvent'))
             ->once()
             ->andReturn(true);
 


### PR DESCRIPTION
The current event system aimed to be as simple as possible, but it is not enough now (see https://github.com/FriendsOfSymfony/FOSMessage/issues/10#issuecomment-174195417). This PR aims to improve the event dispatcher by adding PRE/POST persist events.
